### PR TITLE
Add support for different levels of NTFY notifications on "Resolved" events

### DIFF
--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,6 +56,14 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
+          // If subject contains "Resolved", set Nseverity to "Priority_resolved"
+          if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
+              params.Nseverity = params.Nresolved;
+              if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){
+              throw 'Nresolved value must be passed as an int from 0-5';
+              }
+          }
+        
           // Input validation
           if (!params.URL) {
               throw 'Cannot get ntfy url!';

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,7 +56,7 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
-          // If subject contains "Resolved", set Nseverity to "Priority_resolved"
+          // If subject contains "Resolved", set Nseverity to "Nresolved"
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){


### PR DESCRIPTION
When a problem gets resolved, the NTFY notification can now be at a diffrerent priority then the event itself was.