### PR TITLE
Add support for different levels of NTFY notifications on "Resolved" events

### DIFF
--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -8,6 +8,8 @@ zabbix_export:
           value: '{ALERT.MESSAGE}'
         - name: Nseverity
           value: '{EVENT.NSEVERITY}'
+        - name: Nresolved
+          value: 2
         - name: Password
           value: '{$NTFY.PASS}'
         - name: Priority_average

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -65,7 +65,7 @@ zabbix_export:
               throw 'Nseverity value must be passed as an int from 0-5';
           }
 
-          // If subject contains "Resolved", set Nseverity to "Nresolved"
+          // If subject contains "Resolved", override "Nseverity" to "Nresolved" value.
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -69,7 +69,7 @@ zabbix_export:
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){
-              throw 'Nresolved value must be passed as an int from 0-5';
+                  throw 'Nresolved value must be passed as an int from 0-5';
               }
           }
         

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,21 +56,21 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
+          // Input validation
+          if (!params.URL) {
+              throw 'Cannot get ntfy url!';
+          }
+
+          if (!isInt(params.Nseverity) || params.Nseverity < 0 || params.Nseverity > 5){
+              throw 'Nseverity value must be passed as an int from 0-5';
+          }
+
           // If subject contains "Resolved", set Nseverity to "Nresolved"
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){
               throw 'Nresolved value must be passed as an int from 0-5';
               }
-          }
-        
-          // Input validation
-          if (!params.URL) {
-              throw 'Cannot get ntfy url!';
-          }
-        
-          if (!isInt(params.Nseverity) || params.Nseverity < 0 || params.Nseverity > 5){
-              throw 'Nseverity value must be passed as an int from 0-5';
           }
         
           var response, request = new HttpRequest();

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,6 +56,14 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
+          // If subject contains "Resolved", set Nseverity to "Priority_resolved"
+          if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
+              params.Nseverity = params.Nresolved;
+              if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){
+              throw 'Nresolved value must be passed as an int from 0-5';
+              }
+          }
+        
           // Input validation
           if (!params.URL) {
               throw 'Cannot get ntfy url!';

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,7 +56,7 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
-          // If subject contains "Resolved", set Nseverity to "Priority_resolved"
+          // If subject contains "Resolved", set Nseverity to "Nresolved"
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){


### PR DESCRIPTION
When a problem gets resolved, the NTFY notification can now be at a different priority then the event itself was.