### PR TITLE
Obtain "Topic" from the correct location rather then another useless variable

### DIFF
--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -8,6 +8,8 @@ zabbix_export:
           value: '{ALERT.MESSAGE}'
         - name: Nseverity
           value: '{EVENT.NSEVERITY}'
+        - name: Nresolved
+          value: 2
         - name: Password
           value: '{$NTFY.PASS}'
         - name: Priority_average

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -31,7 +31,7 @@ zabbix_export:
         - name: Token
           value: '{$NTFY.TOKEN}'
         - name: Topic
-          value: '{$ALERT.SENDTO}'
+          value: '{ALERT.SENDTO}' //This value will be obtained from the users "Send To field" under "Users -> Users -> Media Type -> ntfy.sh"
         - name: URL
           value: '{$NTFY.URL}'
         - name: Username

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -65,7 +65,7 @@ zabbix_export:
               throw 'Nseverity value must be passed as an int from 0-5';
           }
 
-          // If subject contains "Resolved", set Nseverity to "Nresolved"
+          // If subject contains "Resolved", override "Nseverity" to "Nresolved" value.
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -69,7 +69,7 @@ zabbix_export:
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){
-              throw 'Nresolved value must be passed as an int from 0-5';
+                  throw 'Nresolved value must be passed as an int from 0-5';
               }
           }
         

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,21 +56,21 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
+          // Input validation
+          if (!params.URL) {
+              throw 'Cannot get ntfy url!';
+          }
+
+          if (!isInt(params.Nseverity) || params.Nseverity < 0 || params.Nseverity > 5){
+              throw 'Nseverity value must be passed as an int from 0-5';
+          }
+
           // If subject contains "Resolved", set Nseverity to "Nresolved"
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){
               throw 'Nresolved value must be passed as an int from 0-5';
               }
-          }
-        
-          // Input validation
-          if (!params.URL) {
-              throw 'Cannot get ntfy url!';
-          }
-        
-          if (!isInt(params.Nseverity) || params.Nseverity < 0 || params.Nseverity > 5){
-              throw 'Nseverity value must be passed as an int from 0-5';
           }
         
           var response, request = new HttpRequest();

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -31,7 +31,7 @@ zabbix_export:
         - name: Token
           value: '{$NTFY.TOKEN}'
         - name: Topic
-          value: '{ALERT.SENDTO}' //This value will be obtained from the users "Send To field" under "Users -> Users -> Media Type -> ntfy.sh"
+          value: '{ALERT.SENDTO}'
         - name: URL
           value: '{$NTFY.URL}'
         - name: Username

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,6 +56,14 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
+          // If subject contains "Resolved", set Nseverity to "Priority_resolved"
+          if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
+              params.Nseverity = params.Nresolved;
+              if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){
+              throw 'Nresolved value must be passed as an int from 0-5';
+              }
+          }
+        
           // Input validation
           if (!params.URL) {
               throw 'Cannot get ntfy url!';

--- a/zbx_ntfy.yaml
+++ b/zbx_ntfy.yaml
@@ -56,7 +56,7 @@ zabbix_export:
                   !isNaN(parseInt(value, 10));
           }
         
-          // If subject contains "Resolved", set Nseverity to "Priority_resolved"
+          // If subject contains "Resolved", set Nseverity to "Nresolved"
           if (params.Subject && typeof params.Subject === 'string' && params.Subject.toLowerCase().includes('resolved')) {
               params.Nseverity = params.Nresolved;
               if (!isInt(params.Nresolved) || params.Nresolved < 0 || params.Nresolved > 5){


### PR DESCRIPTION
ALERT.SENDTO will no longer be an macro variable as this is redundant.

Instead this value will be obtained from the users "Send To field" under "Users -> Users -> Media Type -> ntfy.sh

This improves customizability per user to get zabbix notifications on different topics / departments (or other ways you use NTFY)